### PR TITLE
Generate content for `steps` context

### DIFF
--- a/.github/workflows/contexts.yaml
+++ b/.github/workflows/contexts.yaml
@@ -45,6 +45,12 @@ jobs:
           ref: main
       - name: Install Dependencies
         run: sudo apt-get install --yes jq gron
+      # The `steps` context ONLY contains information about the steps in the
+      # current job that have an `id` specified and have already run.
+      # https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#steps-context
+      - name: Generate steps context
+        id: step_foo
+        run: echo "output_bar=example step output" >> $GITHUB_OUTPUT
       # BUG: any toJSON with single quotes will cause the echo statements to fail.
       # Not sure how to fix this.
       #


### PR DESCRIPTION
This PR adds a step to `.github/workflows/contexts.yaml` which generates content for the `steps` context, so the dumped `steps` context is not empty any more.

Main changes in the `gron` output:

```diff
 json.steps = {};
+json.steps.step_foo = {};
+json.steps.step_foo.outputs = {};
+json.steps.step_foo.outputs.output_bar = "example step output";
+json.steps.step_foo.outcome = "success";
+json.steps.step_foo.conclusion = "success";
```